### PR TITLE
#13 - 로그인 방식 변경

### DIFF
--- a/src/main/java/com/example/plathome/global/advice/ControllerAdvice.java
+++ b/src/main/java/com/example/plathome/global/advice/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.example.plathome.global.advice;
 
+import com.example.plathome.global.dto.MethodArgumentExceptionResponse;
 import com.example.plathome.global.error.ErrorCode;
 import com.example.plathome.global.exception.*;
 import org.hibernate.TypeMismatchException;
@@ -7,8 +8,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentConversionNotSupportedException;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.example.plathome.global.error.ErrorStaticField.*;
 
@@ -80,13 +84,18 @@ public class ControllerAdvice {
         return ResponseEntity.status(NOT_MATCH).body(errorCode);
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorCode> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException ex) {
-        ErrorCode errorCode = ErrorCode.builder()
-                .errorCode(BAD_REQUEST)
-                .message(ex.getMessage())
-                .build();
-        return ResponseEntity.status(BAD_REQUEST).body(errorCode);
+    public MethodArgumentExceptionResponse methodArgumentNotValidException(
+            final MethodArgumentNotValidException e) {
+
+        MethodArgumentExceptionResponse exceptionResponse = new MethodArgumentExceptionResponse(
+                BAD_REQUEST,
+                new ConcurrentHashMap<>()
+        );
+
+        e.getFieldErrors().forEach(exceptionResponse::addValidation);
+        return exceptionResponse;
     }
 
     @ExceptionHandler(MethodArgumentConversionNotSupportedException.class)

--- a/src/main/java/com/example/plathome/global/dto/MethodArgumentExceptionResponse.java
+++ b/src/main/java/com/example/plathome/global/dto/MethodArgumentExceptionResponse.java
@@ -1,0 +1,15 @@
+package com.example.plathome.global.dto;
+
+import org.springframework.validation.FieldError;
+
+import java.util.Map;
+
+public record MethodArgumentExceptionResponse(
+        int statusCode,
+        Map<String, String> validation
+) {
+
+    public void addValidation(final FieldError fieldError) {
+        validation.put(fieldError.getField(), fieldError.getDefaultMessage());
+    }
+}

--- a/src/main/java/com/example/plathome/global/error/ErrorStaticField.java
+++ b/src/main/java/com/example/plathome/global/error/ErrorStaticField.java
@@ -25,9 +25,12 @@ public class ErrorStaticField {
     public static final String EXPIRED_REFRESH_TOKEN = "Refresh 토큰만료! 재로그인 하세요.";
     public static final String EXPIRED_ACCESS_TOKEN = "Access 토큰만료! 재시도 하세요.";
     public static final String CONVERSION_ERROR = "변환 불가능한 타입이 URL에 입력되었습니다";
+    public static final String EMAIL_FORM_ERROR = "Email should end with @ajou.ac.kr";
 
     //chat
     public static final String ROOM_NOT_FOUND = "채팅방을 찾을 수 없습니다.";
     public static final String INVALID_SOCKET_SESSION = "소켓 세션이 유효하지 않습니다.";
+
+
 
 }

--- a/src/main/java/com/example/plathome/login/argumentresolver_interceptor/controller/LoginController.java
+++ b/src/main/java/com/example/plathome/login/argumentresolver_interceptor/controller/LoginController.java
@@ -23,11 +23,10 @@ public class LoginController {
     private final MemberService memberService;
 
     @PostMapping("/token")
-    public String refresh(
+    public MemberWithTokenResponse refresh(
             @Login MemberSession memberSession,
             HttpServletResponse response) {
-        jwtLoginService.refresh(memberSession, response);
-        return "success";
+        return MemberWithTokenResponse.from(jwtLoginService.refresh(memberSession, response));
     }
 
     @GetMapping("/get")

--- a/src/main/java/com/example/plathome/login/argumentresolver_interceptor/interceptor/JwtLoginCheckInterceptor.java
+++ b/src/main/java/com/example/plathome/login/argumentresolver_interceptor/interceptor/JwtLoginCheckInterceptor.java
@@ -25,10 +25,8 @@ public class JwtLoginCheckInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler){
         String requestURI = request.getRequestURI();
-
         log.info("MEMBER 로그인 인증 인터 셉터 실행 [{}]", requestURI);
-        Claims claims = this.getClaims(request);
-        String userId = claims.getSubject();
+        String userId = this.getUserId(request);
         MemberSession memberSession = jwtMemberService.getMemberSessionByUserId(userId);
         request.setAttribute("MemberSession", memberSession);
         UserContext.set(memberSession.username());
@@ -36,7 +34,7 @@ public class JwtLoginCheckInterceptor implements HandlerInterceptor {
         return true;
     }
 
-    private Claims getClaims(HttpServletRequest request){
+    private String getUserId(HttpServletRequest request){
         if (!request.getRequestURI().contains(REFRESH_URL)) {
             return jwtValidateService.validateAccessToken(request);
         }

--- a/src/main/java/com/example/plathome/login/member/common/JwtStaticField.java
+++ b/src/main/java/com/example/plathome/login/member/common/JwtStaticField.java
@@ -4,6 +4,6 @@ public class JwtStaticField {
     public static final String BEARER = "Bearer ";
     public static final String REFRESH_URL = "/token";
 
-    public static final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 15; // Access token is 15 minutes.
+    public static final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 30; // Access token is 15 minutes.
     public static final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24; // Refresh token is one day.
 }

--- a/src/main/java/com/example/plathome/login/member/dto/MemberWithTokenDto.java
+++ b/src/main/java/com/example/plathome/login/member/dto/MemberWithTokenDto.java
@@ -10,6 +10,7 @@ public record MemberWithTokenDto(
         Long id,
         String username,
         String userId,
+        String accessToken,
         String refreshToken
 ){
 
@@ -17,11 +18,12 @@ public record MemberWithTokenDto(
         return MemberWithTokenDto.builder();
     }
 
-    public static MemberWithTokenDto from(Member entity, String refreshToken) {
+    public static MemberWithTokenDto from(Member entity, String accessToken, String refreshToken) {
         return MemberWithTokenDto.builder()
                 .id(entity.getId())
                 .username(entity.getUsername())
                 .userId(entity.getUserId())
+                .accessToken(BEARER + accessToken)
                 .refreshToken(BEARER + refreshToken).build();
     }
 

--- a/src/main/java/com/example/plathome/login/member/dto/request/SignUpForm.java
+++ b/src/main/java/com/example/plathome/login/member/dto/request/SignUpForm.java
@@ -1,5 +1,6 @@
 package com.example.plathome.login.member.dto.request;
 
+import com.example.plathome.login.member.dto.request.annotation.AjouEmail;
 import com.example.plathome.member.domain.Member;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Max;
@@ -11,7 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Builder
 public record SignUpForm(
         @NotBlank @Size(max = 20) String username,
-        @Email @Size(max = 100) String userId,
+        @AjouEmail @Size(max = 100) String userId,
         @NotBlank @Size(max = 32) String password
 ) {
 

--- a/src/main/java/com/example/plathome/login/member/dto/request/annotation/AjouEmail.java
+++ b/src/main/java/com/example/plathome/login/member/dto/request/annotation/AjouEmail.java
@@ -1,0 +1,24 @@
+package com.example.plathome.login.member.dto.request.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Pattern;
+
+import java.lang.annotation.*;
+
+import static com.example.plathome.global.error.ErrorStaticField.EMAIL_FORM_ERROR;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@ReportAsSingleViolation
+@Pattern(regexp=".+@ajou\\.ac\\.kr$")
+public @interface AjouEmail {
+    String message() default EMAIL_FORM_ERROR;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/plathome/login/member/dto/response/MemberWithTokenResponse.java
+++ b/src/main/java/com/example/plathome/login/member/dto/response/MemberWithTokenResponse.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 public record MemberWithTokenResponse(
         String username,
         String userId,
+        String accessToken,
         String refreshToken
 ) {
 
@@ -19,6 +20,7 @@ public record MemberWithTokenResponse(
         return MemberWithTokenResponse.builder()
                 .username(dto.username())
                 .userId(dto.userId())
+                .accessToken(dto.accessToken())
                 .refreshToken(dto.refreshToken()).build();
     }
 


### PR DESCRIPTION
## 변경된 로그인 방식
* 서버에서 토큰 발급시 AccessToken과 RefreshToken모두 ResponseBody에 담아서 전달
* 클라이언트가 서버에 토큰 전송시 AccessToken재발급 URL('/jwt/token")로 요청이 들어오면 Authorization 헤더에 RefreshToken을 담아서 전달
* 클라이언트가 서버에 토큰 전송시 AccessToken재발급 URL('/jwt/token")을 제외한 요청이 오면 Authorization 헤더에 AccessToken을 담아서 전달
* SignUpForm에서 Email형식을 "@ajou.ac.kr"로 제한

this closes #13 