### PR TITLE
#25 - 리팩토링: 로그인 방식 변경

### DIFF
--- a/src/main/java/com/example/plathome/login/argumentresolver_interceptor/argumentresolver/Admin.java
+++ b/src/main/java/com/example/plathome/login/argumentresolver_interceptor/argumentresolver/Admin.java
@@ -1,0 +1,11 @@
+package com.example.plathome.login.argumentresolver_interceptor.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Admin {
+}

--- a/src/main/java/com/example/plathome/login/argumentresolver_interceptor/argumentresolver/JwtAdminArgumentResolver.java
+++ b/src/main/java/com/example/plathome/login/argumentresolver_interceptor/argumentresolver/JwtAdminArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.example.plathome.login.argumentresolver_interceptor.argumentresolver;
+
+import com.example.plathome.global.exception.UnauthorizedException;
+import com.example.plathome.member.domain.MemberSession;
+import com.example.plathome.member.domain.constant.RoleType;
+import com.example.plathome.member.exception.ForbiddenMemberException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j
+public class JwtAdminArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        log.info("JwtAdminArgumentResolver supportsParameter 실행");
+        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Admin.class);
+        boolean hasMemberSessionType = MemberSession.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginAnnotation && hasMemberSessionType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        log.info("JwtAdminArgumentResolver resolveArgument 실행");
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Object memberSession = request.getAttribute("MemberSession");
+        checkAdminRole((MemberSession) memberSession);
+        return memberSession;
+    }
+
+    private void checkAdminRole(MemberSession memberSession) {
+        if (!memberSession.roleType().equals(RoleType.ADMIN)) {
+            throw new ForbiddenMemberException();
+        }
+    }
+}

--- a/src/main/java/com/example/plathome/login/argumentresolver_interceptor/controller/LoginController.java
+++ b/src/main/java/com/example/plathome/login/argumentresolver_interceptor/controller/LoginController.java
@@ -22,7 +22,7 @@ public class LoginController {
     private final JwtLoginService jwtLoginService;
     private final MemberService memberService;
 
-    @PostMapping("/token")
+    @GetMapping("/token")
     public MemberWithTokenResponse refresh(
             @Login MemberSession memberSession,
             HttpServletResponse response) {

--- a/src/main/java/com/example/plathome/login/jwt/common/JwtStaticField.java
+++ b/src/main/java/com/example/plathome/login/jwt/common/JwtStaticField.java
@@ -3,7 +3,9 @@ package com.example.plathome.login.jwt.common;
 public class JwtStaticField {
     public static final String BEARER = "Bearer ";
     public static final String REFRESH_URL = "/token";
-
+    public static final String ACCESS_HEADER = "AccessToken";
+    public static final String REFRESH_HEADER = "RefreshToken";
     public static final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 30; // Access token is 30 minutes.
     public static final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24; // Refresh token is one day.
+
 }

--- a/src/main/java/com/example/plathome/login/jwt/domain/AccessSecretKey.java
+++ b/src/main/java/com/example/plathome/login/jwt/domain/AccessSecretKey.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Component;
 import java.util.Base64;
 
 @Component
-public record SecretKey(@Value("${jwt.secretKey}") String value) {
+public record AccessSecretKey(@Value("${jwt.access.secret-key}") String value) {
 
-    public static final String KEY_PATH = "jwt.secretKey";
+    public static final String ACCESS_KEY_PATH = "jwt.access.secret-key";
     public byte[] getDecoded() {
         return Base64.getDecoder().decode(value);
     }

--- a/src/main/java/com/example/plathome/login/jwt/domain/RefreshSecretKey.java
+++ b/src/main/java/com/example/plathome/login/jwt/domain/RefreshSecretKey.java
@@ -1,0 +1,15 @@
+package com.example.plathome.login.jwt.domain;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+
+@Component
+public record RefreshSecretKey(@Value("${jwt.refresh.secret-key}") String value) {
+
+    public static final String REFRESH_KEY_PATH = "jwt.refresh.secret-key";
+    public byte[] getDecoded() {
+        return Base64.getDecoder().decode(value);
+    }
+}

--- a/src/main/java/com/example/plathome/login/jwt/dto/request/SignUpForm.java
+++ b/src/main/java/com/example/plathome/login/jwt/dto/request/SignUpForm.java
@@ -2,6 +2,7 @@ package com.example.plathome.login.jwt.dto.request;
 
 import com.example.plathome.login.jwt.dto.request.annotation.AjouEmail;
 import com.example.plathome.member.domain.Member;
+import com.example.plathome.member.domain.constant.RoleType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -24,8 +25,6 @@ public record SignUpForm(
                 .username(this.username)
                 .userId(this.userId)
                 .password(encoder.encode(this.password))
-                .createdBy(this.username)
-                .modifiedBy(this.username)
-                .build();
+                .roleType(RoleType.USER).build();
     }
 }

--- a/src/main/java/com/example/plathome/login/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/example/plathome/login/jwt/provider/JwtProvider.java
@@ -1,6 +1,7 @@
 package com.example.plathome.login.jwt.provider;
 
-import com.example.plathome.login.jwt.domain.SecretKey;
+import com.example.plathome.login.jwt.domain.AccessSecretKey;
+import com.example.plathome.login.jwt.domain.RefreshSecretKey;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +17,11 @@ import static com.example.plathome.login.jwt.common.JwtStaticField.*;
 @Service
 public class JwtProvider {
 
-    private final SecretKey secretKey;
+    private final AccessSecretKey accessSecretKey;
+    private final RefreshSecretKey refreshSecretKey;
 
     public String createAccessToken(String userId) {
-        byte[] decodedSecretKey = secretKey.getDecoded();
+        byte[] decodedSecretKey = accessSecretKey.getDecoded();
         return Jwts.builder()
                 .setSubject(userId)
                 .setIssuedAt(new Date())
@@ -29,7 +31,7 @@ public class JwtProvider {
     }
 
     public String createRefreshToken(String userId) {
-        byte[] decodedSecretKey = secretKey.getDecoded();
+        byte[] decodedSecretKey = refreshSecretKey.getDecoded();
         return Jwts.builder()
                 .setSubject(userId)
                 .setId(UUID.randomUUID().toString()) // Unique ID for refresh token

--- a/src/main/java/com/example/plathome/member/domain/MemberSession.java
+++ b/src/main/java/com/example/plathome/member/domain/MemberSession.java
@@ -1,5 +1,6 @@
 package com.example.plathome.member.domain;
 
+import com.example.plathome.member.domain.constant.RoleType;
 import lombok.Builder;
 
 @Builder
@@ -7,7 +8,8 @@ public record MemberSession(
         Long id,
         String username,
         String userId,
-        String password
+        String password,
+        RoleType roleType
         ){
 
     public static final String MEMBER_SESSION = "MemberSession";
@@ -21,8 +23,7 @@ public record MemberSession(
                 .id(member.getId())
                 .username(member.getUsername())
                 .userId(member.getUserId())
-                .password(member.getPassword()).build();
+                .password(member.getPassword())
+                .roleType(member.getRoleType()).build();
     }
-
-
 }

--- a/src/main/java/com/example/plathome/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/plathome/member/repository/MemberRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
-@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUserId(String userId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,7 @@ spring:
     auth-code-expiration-millis: 1800000 # 30 * 60 * 1000 = 30분
 
 
-jwt.secretKey: ${JWT_SECRET_KEY}
+springdoc:
 jwt.access.secret-key: ${JWT_ACCESS_SECRET_KEY}
 jwt.refresh.secret-key: ${JWT_REFRESH_SECRET_KEY}
 


### PR DESCRIPTION
* 액세스 토큰 재발급 요청 방식 GET->POST 방식으로 변경
* AccessToken과 RefreshToken의 Secret-Key 분리
* Token 검증시 Authorization 헤더 -> AccessToken헤더, RefreshToken 헤더로 변경
* admin 리졸버 추가

this closes #25 