### PR TITLE
신고 검증 로직 변동사항

### DIFF
--- a/src/main/java/com/example/plathome/estate_report/exception/OwnEstateReportException.java
+++ b/src/main/java/com/example/plathome/estate_report/exception/OwnEstateReportException.java
@@ -1,0 +1,12 @@
+package com.example.plathome.estate_report.exception;
+
+import com.example.plathome.global.exception.ForbiddenException;
+
+import static com.example.plathome.global.error.ErrorStaticField.ERROR_ESTATE_REPORT_OWN_REPORT;
+
+public class OwnEstateReportException extends ForbiddenException {
+    private static final String MESSAGE = ERROR_ESTATE_REPORT_OWN_REPORT;
+    public OwnEstateReportException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/plathome/estate_report/service/EstateReportService.java
+++ b/src/main/java/com/example/plathome/estate_report/service/EstateReportService.java
@@ -6,6 +6,7 @@ import com.example.plathome.real_estate.repository.EstateRepository;
 import com.example.plathome.estate_report.dto.request.EstateReportForm;
 import com.example.plathome.estate_report.dto.response.EstateReportResponse;
 import com.example.plathome.estate_report.exception.NotFoundEstateReportException;
+import com.example.plathome.estate_report.exception.OwnEstateReportException;
 import com.example.plathome.estate_report.repository.EstateReportRepository;
 import com.example.plathome.member.domain.MemberSession;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +26,14 @@ public class EstateReportService {
     public void report(MemberSession memberSession, EstateReportForm estateReportForm) {
         Estate estate = estateRepository.findById(estateReportForm.estateId())
                 .orElseThrow(NotFoundEstateException::new);
+        getValidateUser(memberSession.id(), estate.getMemberId());
         estateReportRepository.save(estateReportForm.toEntity(memberSession.id()));
+    }
+
+    private static void getValidateUser(long memberId, long expectedId) {
+        if (memberId == expectedId) {
+            throw new OwnEstateReportException();
+        }
     }
 
     public EstateReportResponse getById(long estateReportId) {

--- a/src/main/java/com/example/plathome/user_report/exception/OwnUserReportException.java
+++ b/src/main/java/com/example/plathome/user_report/exception/OwnUserReportException.java
@@ -1,0 +1,12 @@
+package com.example.plathome.user_report.exception;
+
+import com.example.plathome.global.exception.ForbiddenException;
+
+import static com.example.plathome.global.error.ErrorStaticField.ERROR_USER_REPORT_OWN_REPORT;
+
+public class OwnUserReportException extends ForbiddenException {
+    private static final String MESSAGE = ERROR_USER_REPORT_OWN_REPORT;
+    public OwnUserReportException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/com/example/plathome/user_report/service/UserReportService.java
+++ b/src/main/java/com/example/plathome/user_report/service/UserReportService.java
@@ -1,11 +1,13 @@
 package com.example.plathome.user_report.service;
 
+import com.example.plathome.member.domain.Member;
 import com.example.plathome.member.domain.MemberSession;
 import com.example.plathome.member.exception.NotFoundMemberException;
 import com.example.plathome.member.repository.MemberRepository;
 import com.example.plathome.user_report.dto.request.UserReportForm;
 import com.example.plathome.user_report.dto.response.UserReportResponse;
 import com.example.plathome.user_report.exception.NotFoundUserReportException;
+import com.example.plathome.user_report.exception.OwnUserReportException;
 import com.example.plathome.user_report.repository.UserReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,9 +24,16 @@ public class UserReportService {
 
     @Transactional
     public void report(MemberSession memberSession, UserReportForm userReportForm) {
-        memberRepository.findById(userReportForm.targetMemberId()).orElseThrow(NotFoundMemberException::new);
+        Member member = memberRepository.findById(userReportForm.targetMemberId()).orElseThrow(NotFoundMemberException::new);
+        getValidateUser(memberSession.id(), member.getId());
         userReportRepository.save(userReportForm.toEntity(memberSession.id()));
     }
+    private static void getValidateUser(long memberId, long expectedId) {
+        if (memberId == expectedId) {
+            throw new OwnUserReportException();
+        }
+    }
+
 
     public UserReportResponse getById(long userReportId) {
         return userReportRepository.findById(userReportId)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     url: ${LOCAL_DB_URL}
     username: ${LOCAL_DB_USERNAME}
     password: ${LOCAL_DB_PASSWORD}
+    type: com.mysql.cj.jdbc.MysqlConnectionPoolDataSource
   jpa:
     open-in-view: false
     defer-datasource-initialization: true

--- a/src/test/java/com/example/plathome/ObjectBuilder.java
+++ b/src/test/java/com/example/plathome/ObjectBuilder.java
@@ -34,8 +34,8 @@ import static com.example.plathome.global.constant.JwtStaticField.*;
 
 
 public class ObjectBuilder {
-    protected static final long ID = 1L;
-    protected static final long WRONG_ID = 2L;
+    protected static final long ID_1 = 1L;
+    protected static final long ID_2 = 2L;
     protected static final String NICKNAME = "nickname";
     protected static final String EMAIL = "email@ajou.ac.kr";
     protected static final String WRONG_EMAIL = "email";
@@ -62,7 +62,7 @@ public class ObjectBuilder {
 
     protected static Member createMember() {
         return Member.of()
-                .id(ID)
+                .id(ID_1)
                 .nickname(NICKNAME)
                 .email(EMAIL)
                 .password(PASSWORD)
@@ -158,7 +158,7 @@ public class ObjectBuilder {
 
     protected static EstateForm createEstateForm() {
         return EstateForm.of()
-                .memberId(ID)
+                .memberId(ID_1)
                 .location(LOCATION)
                 .area(AREA)
                 .roomType(ROOM_TYPE)
@@ -179,7 +179,7 @@ public class ObjectBuilder {
 
     protected static Estate createEstate() {
         return Estate.builder()
-                .memberId(ID)
+                .memberId(ID_1)
                 .location(LOCATION)
                 .area(AREA)
                 .roomType(ROOM_TYPE)
@@ -200,13 +200,13 @@ public class ObjectBuilder {
 
     protected static ThumbNail createThumbNail() {
         return ThumbNail.builder()
-                .memberId(ID)
+                .memberId(ID_1)
                 .url(THUMBNAIL_URL).build();
     }
 
     protected static UpdateEstateForm createUpdateEstateForm() {
         return UpdateEstateForm.of()
-                .estateId(ID)
+                .estateId(ID_1)
                 .context(CONTEXT)
                 .contractTerm(CONTRACT_TERM)
                 .option(createOption())
@@ -230,27 +230,27 @@ public class ObjectBuilder {
 
     protected static EstateReportForm createEstateReportForm() {
         return EstateReportForm.of()
-                .estateId(ID)
+                .estateId(ID_1)
                 .context(CONTEXT).build();
     }
 
     protected static EstateReport createEstateReport() {
         return EstateReport.builder()
-                .memberId(ID)
-                .estateId(ID)
+                .memberId(ID_1)
+                .estateId(ID_1)
                 .context(CONTEXT).build();
     }
 
     protected static UserReportForm createUserReportForm() {
         return UserReportForm.of()
-                .targetMemberId(ID)
+                .targetMemberId(ID_1)
                 .context(CONTEXT).build();
     }
 
     protected static UserReport createUserReport() {
         return UserReport.builder()
-                .reportMemberId(ID)
-                .targetMemberId(WRONG_ID)
+                .reportMemberId(ID_1)
+                .targetMemberId(ID_2)
                 .context(CONTEXT).build();
     }
     private static Option createOption() {

--- a/src/test/java/com/example/plathome/service/EstateFilterServiceTest.java
+++ b/src/test/java/com/example/plathome/service/EstateFilterServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +30,7 @@ class EstateFilterServiceTest extends ObjectBuilder {
     @Mock private EstateRepository estateRepository;
     @Mock private ThumbNailRepository thumbNailRepository;
 
-    @DisplayName("지도 필터검색: input - Filter | output - List<MapInfoEstateResponse>")
+    @DisplayName("지도 필터 검색: 매칭되는 매물 존재 - 200")
     @Test
     void givenFilter_whenFilteringInMap_thenReturnsMapInfoEstateResponseList(){
         //given
@@ -47,7 +48,23 @@ class EstateFilterServiceTest extends ObjectBuilder {
         then(estateRepository).should().filterSearch(filter);
     }
 
-    @DisplayName("게시판 필터검색: input - Filter | output - List<SimpleEstateResponse>")
+    @DisplayName("지도 필터 검색: 매칭되는 매물 없음 - 200")
+    @Test
+    void givenFilter_whenNoMatchingEstate_thenReturnsEmptyList(){
+        //given
+        Filter filter = createFilter();
+        given(estateRepository.filterSearch(filter)).willReturn(Collections.emptyList());
+
+        //when
+        List<MapInfoEstateResponse> mapInfoEstateResponseList = sut.mapFilter(filter);
+
+        //then
+        assertThat(mapInfoEstateResponseList)
+                .isEmpty();
+        then(estateRepository).should().filterSearch(filter);
+    }
+
+    @DisplayName("게시판 필터 검색: 매칭되는 매물 존재 - 200")
     @Test
     void givenFilter_whenFilteringInBoard_thenReturnsSimpleEstateResponseList(){
         //given
@@ -62,6 +79,22 @@ class EstateFilterServiceTest extends ObjectBuilder {
         assertThat(simpleEstateResponseList)
                 .hasSize(1)
                 .extracting(SimpleEstateResponse::memberId).containsExactly(estate.getMemberId());
+        then(estateRepository).should().filterSearch(filter);
+    }
+
+    @DisplayName("게시판 필터 검색: 매칭되는 매물 없음 - 200")
+    @Test
+    void givenFilter_whenNoMatchingEstateInBoard_thenReturnsEmptyList(){
+        //given
+        Filter filter = createFilter();
+        given(estateRepository.filterSearch(filter)).willReturn(Collections.emptyList());
+
+        //when
+        List<SimpleEstateResponse> simpleEstateResponseList = sut.boardFilter(filter);
+
+        //then
+        assertThat(simpleEstateResponseList)
+                .isEmpty();
         then(estateRepository).should().filterSearch(filter);
     }
 }

--- a/src/test/java/com/example/plathome/service/EstateReportServiceTest.java
+++ b/src/test/java/com/example/plathome/service/EstateReportServiceTest.java
@@ -8,6 +8,7 @@ import com.example.plathome.estate_report.domain.EstateReport;
 import com.example.plathome.estate_report.dto.request.EstateReportForm;
 import com.example.plathome.estate_report.dto.response.EstateReportResponse;
 import com.example.plathome.estate_report.exception.NotFoundEstateReportException;
+import com.example.plathome.estate_report.exception.OwnEstateReportException;
 import com.example.plathome.estate_report.repository.EstateReportRepository;
 import com.example.plathome.estate_report.service.EstateReportService;
 import com.example.plathome.member.domain.MemberSession;
@@ -33,11 +34,11 @@ class EstateReportServiceTest extends ObjectBuilder {
     @Mock private EstateReportRepository estateReportRepository;
     @Mock private EstateRepository estateRepository;
 
-    @DisplayName("매물신고: input - MemberSession & EstateReportForm | output - void")
+    @DisplayName("매물신고: 타인의 매물 신고 - 200")
     @Test
     void givenMemberSessionAndEstateReportForm_whenReportingEstate_thenReturnsSuccess(){
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_2);
         EstateReportForm estateReportForm = createEstateReportForm();
         given(estateRepository.findById(estateReportForm.estateId())).willReturn(Optional.of(createEstate()));
         given(estateReportRepository.save(any(EstateReport.class))).willReturn(any(EstateReport.class));
@@ -50,11 +51,11 @@ class EstateReportServiceTest extends ObjectBuilder {
         then(estateReportRepository).should().save(any(EstateReport.class));
     }
 
-    @DisplayName("매물신고: input - MemberSession & Wrong EstateReportForm | output - 404")
+    @DisplayName("매물신고: 존재하지 않는 매물일 경우 - 404")
     @Test
-    void givenMemberSessionAndWrongEstateReportForm_whenReportingEstate_thenReturnsNotFoundException(){
+    void givenNonExistentEstateId_whenReportingEstate_thenThrowsNotFoundException(){
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         EstateReportForm estateReportForm = createEstateReportForm();
         given(estateRepository.findById(estateReportForm.estateId())).willReturn(Optional.empty());
 
@@ -64,41 +65,54 @@ class EstateReportServiceTest extends ObjectBuilder {
         then(estateReportRepository).shouldHaveNoInteractions();
     }
 
-    @DisplayName("단일조회: input - EstateReportId | output - EstateReportResponse")
+    @DisplayName("매물 신고: 본인의 매물 신고 - 403")
     @Test
-    void givenEstateReportId_whenGettingById_thenReturnsEstateReportResponse(){
+    void givenOwnEstateId_whenReportingEstate_thenThrowsOwnEstateReportException(){
+        //given
+        MemberSession memberSession = createMemberSession(ID_1);
+        EstateReportForm estateReportForm = createEstateReportForm();
+        given(estateRepository.findById(estateReportForm.estateId())).willReturn(Optional.of(createEstate()));
+
+        //when & then
+        assertThrows(OwnEstateReportException.class, () -> sut.report(memberSession, estateReportForm));
+        then(estateRepository).should().findById(estateReportForm.estateId());
+        then(estateReportRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("매물 신고 단일 조회: 주어진 매물 신고 ID로 조회 시, 매물 신고 내역 응답 반환 - 200")
+    @Test
+    void givenEstateReportId_whenQuerying_thenReturnsEstateReportResponse(){
         //given
         EstateReport estateReport = createEstateReport();
-        given(estateReportRepository.findById(ID)).willReturn(Optional.of(estateReport));
+        given(estateReportRepository.findById(ID_1)).willReturn(Optional.of(estateReport));
 
         //when
-        EstateReportResponse estateReportResponse = sut.getById(ID);
+        EstateReportResponse estateReportResponse = sut.getById(ID_1);
 
         //then
         assertThat(estateReportResponse)
                 .hasFieldOrPropertyWithValue("memberId", estateReport.getMemberId())
                 .hasFieldOrPropertyWithValue("estateId", estateReport.getEstateId())
                 .hasFieldOrPropertyWithValue("context", estateReport.getContext());
-        then(estateReportRepository).should().findById(ID);
+        then(estateReportRepository).should().findById(ID_1);
     }
 
-    @DisplayName("단일조회: input - Wrong EstateReportId | output - 404")
+    @DisplayName("매물 신고 단일 조회: 존재하지 않는 매물 신고 내역일 경우 - 404")
     @Test
-    void givenWrongEstateReportId_whenGettingById_thenReturnsNotFoundException(){
+    void givenNonExistentEstateReportId_whenQuerying_thenThrowsNotFoundException(){
         //given
-        given(estateReportRepository.findById(ID)).willReturn(Optional.empty());
+        given(estateReportRepository.findById(ID_1)).willReturn(Optional.empty());
 
         //when & then
-        assertThrows(NotFoundEstateReportException.class, () -> sut.getById(ID));
-        then(estateReportRepository).should().findById(ID);
+        assertThrows(NotFoundEstateReportException.class, () -> sut.getById(ID_1));
+        then(estateReportRepository).should().findById(ID_1);
     }
 
-    @DisplayName("모두조회: input - Nothing | output - List<EstateReportResponse>")
+    @DisplayName("매물 신고 전체 조회: 전체 조회 - 200")
     @Test
-    void givenNothing_whenGettingAll_thenReturnsEstateReportResponseList(){
+    void givenNothing_whenGettingAllEstateReports_thenReturnsEstateReportResponseList(){
         //given
         EstateReport estateReport = createEstateReport();
-
         given(estateReportRepository.findAll()).willReturn(List.of(estateReport));
 
         //when
@@ -107,20 +121,20 @@ class EstateReportServiceTest extends ObjectBuilder {
         //then
         assertThat(estateReportResponseList)
                 .hasSize(1)
-                .extracting(EstateReportResponse::estateId).containsExactly(ID);
+                .extracting(EstateReportResponse::estateId).containsExactly(ID_1);
         then(estateReportRepository).should().findAll();
     }
 
-    @DisplayName("신고내역삭제: input - EstateReportId | output - void")
+    @DisplayName("매물 신고 삭제: 매물 신고 ID로 삭제 - 204")
     @Test
-    void givenEstateReportId_whenDeleting_thenReturnsSuccess() {
+    void givenEstateReportId_whenDeletingById_thenReturnsNoContent() {
         //given
-        willDoNothing().given(estateReportRepository).deleteById(ID);
+        willDoNothing().given(estateReportRepository).deleteById(ID_1);
 
         //when
-        sut.delete(ID);
+        sut.delete(ID_1);
 
         //then
-        then(estateReportRepository).should().deleteById(ID);
+        then(estateReportRepository).should().deleteById(ID_1);
     }
 }

--- a/src/test/java/com/example/plathome/service/EstateServiceTest.java
+++ b/src/test/java/com/example/plathome/service/EstateServiceTest.java
@@ -40,7 +40,7 @@ class EstateServiceTest extends ObjectBuilder {
     @Mock private RequestedRepository requestedRepository;
     @Mock private ThumbNailRepository thumbNailRepository;
 
-    @DisplayName("매물등록: input - EstateForm | output - void")
+    @DisplayName("매물 등록: 관리자가 매물 등록을 승인할 경우 - 200")
     @Test
     void givenEstateForm_whenRegistering_thenReturnsSuccess() {
         //given
@@ -58,9 +58,9 @@ class EstateServiceTest extends ObjectBuilder {
         then(requestedRepository).should().deleteByMemberId(estateForm.memberId());
     }
 
-    @DisplayName("매물등록: input - EstateForm With Dup MemberId | output - 400")
+    @DisplayName("매물 등록: 이미 매물을 올린 회원일 경우 - 400")
     @Test
-    void givenEstateFormWithDupMemberId_whenRegistering_thenReturnsDuplicationException() {
+    void givenDuplicationMemberId_whenRegistering_thenReturnsDuplicationException() {
         //given
         EstateForm estateForm = createEstateForm();
         Estate estate = createEstate();
@@ -73,7 +73,7 @@ class EstateServiceTest extends ObjectBuilder {
         then(requestedRepository).shouldHaveNoInteractions();
     }
 
-    @DisplayName("지도조회: input - Nothing | output - List<MapInfoEstateResponse>")
+    @DisplayName("지도 조회: 매물이 존재하는 경우 - 200")
     @Test
     void givenNothing_whenGettingAllMapInfo_thenReturnsMapInfoEstateResponseList() {
         //given
@@ -90,7 +90,7 @@ class EstateServiceTest extends ObjectBuilder {
         then(estateRepository).should().findAll();
     }
 
-    @DisplayName("게시판조회: input - Nothing | output - List<SimpleEstateResponse>")
+    @DisplayName("게시판 조회: 매물이 존재하는 경우 - 200")
     @Test
     void givenNothing_whenGettingAllSimpleInfo_thenReturnsSimpleEstateResponseList() {
         //given
@@ -107,11 +107,11 @@ class EstateServiceTest extends ObjectBuilder {
         then(estateRepository).should().findAll();
     }
 
-    @DisplayName("상세조회: input - EstateId | output - EstateResponse")
+    @DisplayName("매물 상세 조회: 매물ID로 조회할 경우 - 200")
     @Test
     void givenEstateId_whenGettingDetail_thenReturnsEstateResponse() {
         //given
-        long estateId = ID;
+        long estateId = ID_1;
         Estate estate = createEstate();
         given(estateRepository.findById(estateId)).willReturn(Optional.of(estate));
         given(thumbNailRepository.findByMemberId(estate.getMemberId())).willReturn(List.of(createThumbNail()));
@@ -127,11 +127,11 @@ class EstateServiceTest extends ObjectBuilder {
         then(thumbNailRepository).should().findByMemberId(estate.getMemberId());
     }
 
-    @DisplayName("상세조회: input - Wrong EstateId | output - 404")
+    @DisplayName("매물 상세 조회: 매물ID에 매칭되는 매물이 존재하지 않을 경우 - 404")
     @Test
-    void givenWrongEstateId_whenGettingDetail_thenReturnsNotFoundException() {
+    void givenNonExistentEstateId_whenGettingDetail_thenReturnsNotFoundException() {
         //given
-        long estateId = ID;
+        long estateId = ID_1;
         given(estateRepository.findById(estateId)).willReturn(Optional.empty());
 
         //when & then
@@ -140,90 +140,86 @@ class EstateServiceTest extends ObjectBuilder {
         then(thumbNailRepository).shouldHaveNoInteractions();
     }
 
-    @DisplayName("매물 삭제: input - MemberSession & EstateId | output - void")
+    @DisplayName("매물 삭제: 본인의 매물을 삭제 요청을 할 경우 - 200")
     @Test
     void givenMemberSessionAndEstateId_whenDeletingEstate_thenReturnsSuccess() {
         //given
-        MemberSession memberSession = createMemberSession(ID);
-        given(estateRepository.findById(ID)).willReturn(Optional.of(createEstate()));
-        willDoNothing().given(estateRepository).deleteById(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
+        given(estateRepository.findById(ID_1)).willReturn(Optional.of(createEstate()));
+        willDoNothing().given(estateRepository).deleteById(ID_1);
 
         //when
-        sut.delete(memberSession, ID);
+        sut.delete(memberSession, ID_1);
 
         //then
-        then(estateRepository).should().findById(ID);
-        then(estateRepository).should().deleteById(ID);
+        then(estateRepository).should().findById(ID_1);
+        then(estateRepository).should().deleteById(ID_1);
     }
 
-    @DisplayName("매물 삭제: input - Wrong MemberSession & EstateId | output - 404")
+    @DisplayName("매물 삭제: 매물ID에 매칭되는 매물이 존재하지 않는 경우 - 404 ")
     @Test
-    void givenWrongMemberSessionAndEstateId_whenDeletingEstate_thenReturnsNotFoundException() {
+    void givenNonExistentEstateId_whenDeletingEstate_thenReturnsNotFoundException() {
         //given
-        MemberSession memberSession = createMemberSession(ID);
-        given(estateRepository.findById(ID)).willReturn(Optional.empty());
+        MemberSession memberSession = createMemberSession(ID_1);
+        given(estateRepository.findById(ID_1)).willReturn(Optional.empty());
 
-        //when
-        assertThrows(NotFoundEstateException.class, () -> sut.delete(memberSession, ID));
-
-        //then
-        then(estateRepository).should().findById(ID);
+        //when & then
+        assertThrows(NotFoundEstateException.class, () -> sut.delete(memberSession, ID_1));
+        then(estateRepository).should().findById(ID_1);
         then(estateRepository).shouldHaveNoMoreInteractions();
     }
 
-    @DisplayName("매물 삭제: input - Forbidden MemberSession & EstateId | output - 403")
+    @DisplayName("매물 삭제: 타인의 매물을 삭제하려는 경우 - 403")
     @Test
-    void givenForbiddenMemberSessionAndEstateId_whenDeletingEstate_thenReturnsForbiddenException() {
+    void givenForbiddenMemberId_whenDeletingEstate_thenReturnsForbiddenException() {
         //given
-        MemberSession memberSession = createMemberSession(WRONG_ID);
-        given(estateRepository.findById(ID)).willReturn(Optional.of(createEstate()));
+        MemberSession memberSession = createMemberSession(ID_2);
+        given(estateRepository.findById(ID_1)).willReturn(Optional.of(createEstate()));
 
-        //when
-        assertThrows(ForbiddenMemberException.class, () -> sut.delete(memberSession, ID));
-
-        //then
-        then(estateRepository).should().findById(ID);
+        //when & then
+        assertThrows(ForbiddenMemberException.class, () -> sut.delete(memberSession, ID_1));
+        then(estateRepository).should().findById(ID_1);
         then(estateRepository).shouldHaveNoMoreInteractions();
     }
 
-    @DisplayName("매물 수정: input - MemberSession & UpdateEstateForm | output - void")
+    @DisplayName("매물 수정: 본인의 매물을 수정하려는 경우 - 200")
     @Test
     void givenMemberSessionAndUpdateEstateForm_whenUpdatingEstate_thenReturnsSuccess() {
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         UpdateEstateForm updateEstateForm = createUpdateEstateForm();
-        given(estateRepository.findById(ID)).willReturn(Optional.of(createEstate()));
+        given(estateRepository.findById(ID_1)).willReturn(Optional.of(createEstate()));
 
         //when
         sut.update(memberSession, updateEstateForm);
 
         //then
-        then(estateRepository).should().findById(ID);
+        then(estateRepository).should().findById(ID_1);
     }
 
-    @DisplayName("매물 수정: input - Wrong MemberSession & UpdateEstateForm | output - 404")
+    @DisplayName("매물 수정: 매물ID에 매핑되는 매물이 존재하지 않을 경우 - 404")
     @Test
-    void givenWrongMemberSessionAndUpdateEstateForm_whenUpdatingEstate_thenReturnsNotFoundException() {
+    void givenNonExistentEstateId_whenUpdatingEstate_thenReturnsNotFoundException() {
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         UpdateEstateForm updateEstateForm = createUpdateEstateForm();
-        given(estateRepository.findById(ID)).willReturn(Optional.empty());
+        given(estateRepository.findById(ID_1)).willReturn(Optional.empty());
 
         //when & then
         assertThrows(NotFoundEstateException.class, () -> sut.update(memberSession, updateEstateForm));
-        then(estateRepository).should().findById(ID);
+        then(estateRepository).should().findById(ID_1);
     }
 
-    @DisplayName("매물 수정: input - Forbidden MemberSession & UpdateEstateForm | output - 403")
+    @DisplayName("매물 수정: 타인의 매물을 수정하려는 경우 - 403")
     @Test
-    void givenForbiddenMemberSessionAndUpdateEstateForm_whenUpdatingEstate_thenReturnsForbiddenException() {
+    void givenForbiddenMemberId_whenUpdatingEstate_thenReturnsForbiddenException() {
         //given
-        MemberSession memberSession = createMemberSession(WRONG_ID);
+        MemberSession memberSession = createMemberSession(ID_2);
         UpdateEstateForm updateEstateForm = createUpdateEstateForm();
-        given(estateRepository.findById(ID)).willReturn(Optional.of(createEstate()));
+        given(estateRepository.findById(ID_1)).willReturn(Optional.of(createEstate()));
 
         //when & then
         assertThrows(ForbiddenMemberException.class, () -> sut.update(memberSession, updateEstateForm));
-        then(estateRepository).should().findById(ID);
+        then(estateRepository).should().findById(ID_1);
     }
 }

--- a/src/test/java/com/example/plathome/service/JwtValidateServiceTest.java
+++ b/src/test/java/com/example/plathome/service/JwtValidateServiceTest.java
@@ -32,7 +32,7 @@ class JwtValidateServiceTest extends ObjectBuilder {
     @Mock private AccessSecretKey accessSecretKey;
     @Mock private RefreshSecretKey refreshSecretKey;
     
-    @DisplayName("AcessToken 검증: input - HttpServletRequest | output StringMemberId")
+    @DisplayName("AcessToken 검증: 유효한 토큰이 들어왔을 경우 - 200")
     @Test
     void givenHttpServletRequest_whenValidationAccessToken_thenReturnsStringMemberId(){
       //given
@@ -48,9 +48,9 @@ class JwtValidateServiceTest extends ObjectBuilder {
         then(accessSecretKey).should().getDecoded();
     }
 
-    @DisplayName("AcessToken 검증: input - HttpServletRequest With Invalid Token | output 401")
+    @DisplayName("AcessToken 검증: 유효하지 않은 토큰이 들어왔을 경우 - 401")
     @Test
-    void givenHttpServletRequestWithInvalidToken_whenValidationAccessToken_thenReturnsUnAuthorizedException(){
+    void givenInvalidAccessToken_whenValidationAccessToken_thenReturnsUnAuthorizedException(){
         //given
         String accessToken = createAccessToken(WRONG_SECRET_KEY);
         MockHttpServletRequest request = createHttpRequestWithToken(ACCESS_HEADER, accessToken);
@@ -61,9 +61,9 @@ class JwtValidateServiceTest extends ObjectBuilder {
         then(accessSecretKey).should().getDecoded();
     }
 
-    @DisplayName("AcessToken 검증: input - HttpServletRequest With Expired Token | output 401")
+    @DisplayName("AcessToken 검증: 만료된 토큰이 들어왔을 경우 - 401")
     @Test
-    void givenHttpServletRequestWithExpiredToken_whenValidationAccessToken_thenReturnsUnAuthorizedException(){
+    void givenExpiredAccessToken_whenValidationAccessToken_thenReturnsUnAuthorizedException(){
         //given
         String expiredAccessToken = createExpiredAccessToken(SECRET_KEY);
         MockHttpServletRequest request = createHttpRequestWithToken(ACCESS_HEADER, expiredAccessToken);
@@ -74,7 +74,7 @@ class JwtValidateServiceTest extends ObjectBuilder {
         then(accessSecretKey).should().getDecoded();
     }
 
-    @DisplayName("RefreshToken 검증: input - HttpServletRequest | output StringMemberId")
+    @DisplayName("RefreshToken 검증: 유효한 토큰이 들어왔을 경우 - 200")
     @Test
     void givenHttpServletRequest_whenValidationRefreshToken_thenReturnsStringMemberId(){
         //given
@@ -94,9 +94,9 @@ class JwtValidateServiceTest extends ObjectBuilder {
         then(refreshTokenRedisService).should().getData(String.valueOf(1L));
     }
 
-    @DisplayName("RefreshToken 검증: input - HttpServletRequest With Invalid Token | output 401")
+    @DisplayName("RefreshToken 검증: 유효하지 않은 토큰이 들어왔을 경우 - 401")
     @Test
-    void givenHttpServletRequestWithInvalidToken_whenValidationRefreshToken_thenReturnsUnAuthorizedException(){
+    void givenInvalidRefreshToken_whenValidationRefreshToken_thenReturnsUnAuthorizedException(){
         //given
         String refreshToken = createRefreshToken(WRONG_SECRET_KEY);
         MockHttpServletRequest request = createHttpRequestWithToken(REFRESH_HEADER ,refreshToken);
@@ -108,9 +108,9 @@ class JwtValidateServiceTest extends ObjectBuilder {
         then(refreshTokenRedisService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("RefreshToken 검증: input - HttpServletRequest With Expired Token | output 401")
+    @DisplayName("RefreshToken 검증:  만료된 토큰이 들어왔을 경우 - 401")
     @Test
-    void givenHttpServletRequestWithExpiredToken_whenValidationRefreshToken_thenReturnsUnAuthorizedException(){
+    void givenExpiredRefreshToken_whenValidationRefreshToken_thenReturnsUnAuthorizedException(){
         //given
         String expiredRefreshToken = createExpiredRefreshToken(SECRET_KEY);
         MockHttpServletRequest request = createHttpRequestWithToken(REFRESH_HEADER, expiredRefreshToken);

--- a/src/test/java/com/example/plathome/service/LoginServiceTest.java
+++ b/src/test/java/com/example/plathome/service/LoginServiceTest.java
@@ -40,7 +40,7 @@ class LoginServiceTest extends ObjectBuilder {
     @Mock private RefreshTokenRedisService refreshTokenRedisService;
     @Mock private MailMemberService mailMemberService;
 
-    @DisplayName("회원가입: input - SignUpForm | output - MemberResponse")
+    @DisplayName("회원 가입: 올바른 입력 값이 들어온 경우 - 200")
     @Test
     void givenSignUpForm_whenSingingUp_thenReturnsMemberResponse(){
         //given
@@ -64,9 +64,9 @@ class LoginServiceTest extends ObjectBuilder {
         then(memberRepository).should().save(any(Member.class));
     }
 
-    @DisplayName("회원가입: input - SignUpForm With Dup Email | output - 400")
+    @DisplayName("회원 가입: 이미 존재하는 이메일을 입력한 경우 - 400")
     @Test
-    void givenSignUpFormWithDuplicationEmail_whenSingingUp_thenReturnsDuplicationException(){
+    void givenDuplicationEmail_whenSingingUp_thenReturnsDuplicationException(){
         //given
         SignUpForm signUpForm = createSignUpForm();
         Member member = createMember();
@@ -80,9 +80,9 @@ class LoginServiceTest extends ObjectBuilder {
         then(mailMemberService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("회원가입: input - SignUpForm With Dup Nickname | output - 400")
+    @DisplayName("회원 가입: 이미 존재하는 닉네임을 입력한 경우 - 400")
     @Test
-    void givenSignUpFormWithDuplicationNickname_whenSingingUp_thenReturnsDuplicationExceptions(){
+    void givenDuplicationNickname_whenSingingUp_thenReturnsDuplicationExceptions(){
         //given
         SignUpForm wrongEmailSignUpForm = createWrongEmailSignUpForm();
         Member member = createMember();
@@ -96,7 +96,7 @@ class LoginServiceTest extends ObjectBuilder {
         then(mailMemberService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("로그인: input - LoginForm | output - TokensResponse")
+    @DisplayName("로그인: 올바른 입력 값이 들어온 경우 - 200")
     @Test
     void givenLoginForm_whenLogin_thenReturnsTokenResponse(){
         //given
@@ -124,9 +124,9 @@ class LoginServiceTest extends ObjectBuilder {
         then(refreshTokenRedisService).should().setData(member.getId().toString(), refreshToken);
     }
 
-    @DisplayName("로그인: input - LoginForm With Wrong Email | output - 404")
+    @DisplayName("로그인: 존재하지 않는 이메일을 입력한 경우 - 404")
     @Test
-    void givenLoginFormWithWrongEmail_whenLogin_thenReturnsNotFoundException(){
+    void givenNonExistentEmail_whenLogin_thenReturnsNotFoundException(){
         //given
         LoginForm loginForm = createLoginForm();
         given(memberRepository.findByEmail(loginForm.email())).willReturn(Optional.empty());
@@ -139,9 +139,9 @@ class LoginServiceTest extends ObjectBuilder {
         then(refreshTokenRedisService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("로그인: input - LoginForm With Wrong Password | output - 405")
+    @DisplayName("로그인: 잘못된 비밀 번호를 입력한 경우 - 405")
     @Test
-    void givenLoginFormWithWrongPassword_whenLogin_thenReturnsNotMatchException(){
+    void givenWrongPassword_whenLogin_thenReturnsNotMatchException(){
         //given
         LoginForm loginForm = createLoginForm();
         Member member = createMember();
@@ -156,11 +156,11 @@ class LoginServiceTest extends ObjectBuilder {
         then(refreshTokenRedisService).shouldHaveNoInteractions();
     }
 
-    @DisplayName("재발급: input - MemberSession | output - TokenResponse")
+    @DisplayName("재발급: 올바른 MemberSession으로 토큰 재 발급을 시도한 경우 - 200")
     @Test
     void givenMemberSession_whenRefreshing_thenReturnsTokenResponse(){
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         String stringMemberId = String.valueOf(memberSession.id());
         String accessToken = createAccessToken(SECRET_KEY);
         String refreshToken = createRefreshToken(SECRET_KEY);
@@ -180,11 +180,11 @@ class LoginServiceTest extends ObjectBuilder {
         then(refreshTokenRedisService).should().setData(stringMemberId, refreshToken);
     }
 
-    @DisplayName("로그아웃: input - MemberSession | output - void")
+    @DisplayName("로그 아웃: 올바른 MemberSession으로 로그 아웃을 시도할 경우 - 200")
     @Test
-    void givenMemberSession_whenLogout_thenReturnsSuccess() {
+    void givenMemberSession_whenLogout_thenReturnsNoContent() {
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         willDoNothing().given(refreshTokenRedisService).deleteData(memberSession.email());
 
         //when

--- a/src/test/java/com/example/plathome/service/MemberServiceTest.java
+++ b/src/test/java/com/example/plathome/service/MemberServiceTest.java
@@ -29,11 +29,11 @@ class MemberServiceTest extends ObjectBuilder {
     @Mock
     private MemberRepository memberRepository;
     
-    @DisplayName("본인조회: input - MemberSession | output - MemberResponse")
+    @DisplayName("본인 조회: 올바른 MemberSession으로 본인을 조회한 경우 - 200")
     @Test
     void givenMemberSession_whenRequestingMemberInfo_thenReturnsMemberResponse(){
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.ofNullable(createMember()));
 
         //when
@@ -41,17 +41,17 @@ class MemberServiceTest extends ObjectBuilder {
 
         //then
         assertThat(memberResponse)
-                .hasFieldOrPropertyWithValue("id", ID)
+                .hasFieldOrPropertyWithValue("id", ID_1)
                 .hasFieldOrPropertyWithValue("nickname", NICKNAME)
                 .hasFieldOrPropertyWithValue("email", EMAIL);
         then(memberRepository).should().findByEmail(EMAIL);
     }
 
-    @DisplayName("본인조회: input - Wrong MemberSession | output - 404")
+    @DisplayName("본인 조회: 존재하지 않는 Email로 MemberSession이 들어온 경우 - 404")
     @Test
-    void givenWrongMemberSession_whenRequestingMemberInfo_thenReturnsNotFoundException(){
+    void givenNonExistentEmail_whenRequestingMemberInfo_thenReturnsNotFoundException(){
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         given(memberRepository.findByEmail(EMAIL)).willReturn(Optional.empty());
 
         //when & then
@@ -59,11 +59,11 @@ class MemberServiceTest extends ObjectBuilder {
         then(memberRepository).should().findByEmail(EMAIL);
     }
 
-    @DisplayName("타인조회: input - MemberId | output - MemberResponse")
+    @DisplayName("타인 조회: MemberId로 회원을 조회한 경우 - 200")
     @Test
     void givenMemberId_whenRequestingMemberInfo_thenReturnsMemberResponse(){
         //given
-        long memberId = ID;
+        long memberId = ID_1;
         given(memberRepository.findById(memberId)).willReturn(Optional.of(createMember()));
 
         //when
@@ -71,17 +71,17 @@ class MemberServiceTest extends ObjectBuilder {
 
         //then
         assertThat(memberResponse)
-                .hasFieldOrPropertyWithValue("id", ID)
+                .hasFieldOrPropertyWithValue("id", ID_1)
                 .hasFieldOrPropertyWithValue("nickname", NICKNAME)
                 .hasFieldOrPropertyWithValue("email", EMAIL);
         then(memberRepository).should().findById(memberId);
     }
 
-    @DisplayName("타인조회: input - Wrong MemberId | output - 404")
+    @DisplayName("타인 조회: 존재하지 않는 MemberId로 회원을 조회한 경우 - 404")
     @Test
-    void givenWrongMemberId_whenRequestingMemberInfo_thenReturnsNotFoundException(){
+    void givenNonExistentMemberId_whenRequestingMemberInfo_thenReturnsNotFoundException(){
         //given
-        long memberId = ID;
+        long memberId = ID_1;
         given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
         //when & then
@@ -89,11 +89,11 @@ class MemberServiceTest extends ObjectBuilder {
         then(memberRepository).should().findById(memberId);
     }
 
-    @DisplayName("인터셉터: input - MemberId | output - MemberSession")
+    @DisplayName("인터 셉터: MemberId로 MemberSession을 조회하는 경우 - 200")
     @Test
     void givenMemberId_whenRequestingMemberSession_thenReturnsMemberSession(){
         //given
-        long memberId = ID;
+        long memberId = ID_1;
         given(memberRepository.findById(memberId)).willReturn(Optional.of(createMember()));
 
         //when
@@ -101,7 +101,7 @@ class MemberServiceTest extends ObjectBuilder {
 
         //then
         assertThat(memberSession)
-                .hasFieldOrPropertyWithValue("id", ID)
+                .hasFieldOrPropertyWithValue("id", ID_1)
                 .hasFieldOrPropertyWithValue("nickname", NICKNAME)
                 .hasFieldOrPropertyWithValue("email", EMAIL)
                 .hasFieldOrPropertyWithValue("password", PASSWORD)
@@ -109,11 +109,11 @@ class MemberServiceTest extends ObjectBuilder {
         then(memberRepository).should().findById(memberId);
     }
 
-    @DisplayName("인터셉터: input - Wrong MemberId | output - 404")
+    @DisplayName("인터 셉터: 존재하지 않는 MemberId로 MemberSession을 조회하는 경우 - 404")
     @Test
-    void givenWrongMemberId_whenRequestingMemberSession_thenReturnsNotFoundException(){
+    void givenNonExistentMemberId_whenRequestingMemberSession_thenReturnsNotFoundException(){
         //given
-        long memberId = ID;
+        long memberId = ID_1;
         given(memberRepository.findById(memberId)).willReturn(Optional.empty());
 
         //when & then
@@ -121,11 +121,11 @@ class MemberServiceTest extends ObjectBuilder {
         then(memberRepository).should().findById(memberId);
     }
 
-    @DisplayName("회원삭제: input - MemberId | output - Void")
+    @DisplayName("회원 삭제: 회원 탈퇴를 진행할 경우 - 200")
     @Test
     void givenMemberSession_whenDeletingMember_thenSuccess(){
         //given
-        MemberSession memberSession = createMemberSession(ID);
+        MemberSession memberSession = createMemberSession(ID_1);
         willDoNothing().given(memberRepository).deleteById(memberSession.id());
 
         //when

--- a/src/test/java/com/example/plathome/service/RequestedServiceTest.java
+++ b/src/test/java/com/example/plathome/service/RequestedServiceTest.java
@@ -1,7 +1,11 @@
 package com.example.plathome.service;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@DisplayName("비지니스 로직 - 등록 요청 매물")
+@ExtendWith(MockitoExtension.class)
 class RequestedServiceTest {
 
 }


### PR DESCRIPTION
* 신고 검증 로직에서 유효한 회원을 신고하는지, 유효한 매물을 신고하는지에 대한 로직 추가
* 테스트 메서드 네이밍 변경, 변경된 검증로직 반영
* **datasource.type**: `hikari` -> `mysql`

this closes #87 